### PR TITLE
Fix adding items without categories to cart from PDP issue

### DIFF
--- a/src/pages/Details.js
+++ b/src/pages/Details.js
@@ -409,7 +409,7 @@ class Details extends PureComponent {
                     quantity: 1,
                   };
                   this.addProductToCart(cartItem);
-                  this.setState({ isInCart: true });
+                  this.setState({ noAttributeProduct: cartItem, isInCart: true });
                   this.changeButtonContent('REMOVE ITEM');
                   this.showStatus(
                     'Product successfully added to cart!',


### PR DESCRIPTION
In this pull request, I fixed the issue that arises from adding a product that does not have categories to cart from the PDP page. Before now, adding such items to the cart from the PDP page produces a blank page.